### PR TITLE
Fix problems with storing offset on xenial

### DIFF
--- a/timekeeper.conf
+++ b/timekeeper.conf
@@ -1,7 +1,7 @@
 description "Timekeeper is a utility to keep/restore RTC offset for Qualcomm devices"
 
-start on android
-stop on stopping lxc-android-config
+start on android-container
+stop on runlevel [016]
 
 pre-start script
 	timekeeper restore || true


### PR DESCRIPTION
When timekeeper stops with the Android container, the time offset is incorrect (it's normally read as negative). This change makes timekeeper store the offset as soon as the system begins rebooting or shutting down instead of waiting for the container to stop.